### PR TITLE
<html> tag outside the shim shouldn't be there.

### DIFF
--- a/views/template/layout.jade
+++ b/views/template/layout.jade
@@ -1,7 +1,9 @@
-doctype 5
-<!--[if IE 8]>         <html class="no-js lt-ie9" lang="en" > <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
-html
+!!! 5
+//if IE 8
+  <html class="no-js lt-ie9" lang="en">
+//[if gt IE 8]><!
+html.no-js(lang='en')
+  //<![endif]
   include head
   body
     block content


### PR DESCRIPTION
Previous does not pass validation. Now with more Jade and will still generate the ending </html>.

The goal is the following (adjusted whitespace):

``` html
<!DOCTYPE html>
<!--[if IE 8]><html class="no-js lt-ie9" lang="en"><![endif]-->
<!--[if gt IE 8]><!--><html class="no-js" lang="en"> <!--<![endif]-->
<head>
```

But the current code renders to the following (adjusted whitespace)::

``` html
<!DOCTYPE html>
<!--[if IE 8]><html class="no-js lt-ie9" lang="en" ><![endif]-->
<!--[if gt IE 8]><!--><html class="no-js" lang="en" ><!--<![endif]-->
<html>
<head>
```
